### PR TITLE
Fixed variable extraction to not override current scope.

### DIFF
--- a/_posts/2009-09-30-simple-php-template-engine.markdown
+++ b/_posts/2009-09-30-simple-php-template-engine.markdown
@@ -394,17 +394,11 @@ class Template {
   }
 
   public function __set($name, $value) {
-    if($name == 'view_template_file') {
-      throw new Exception("Cannot bind variable named 'view_template_file'");
-    }
     $this->vars[$name] = $value;
   }
 
   public function render($view_template_file) {
-    if(array_key_exists('view_template_file', $this->vars)) {
-      throw new Exception("Cannot bind variable called 'view_template_file'");
-    }
-    extract($this->vars);
+    extract($this->vars, EXTR_SKIP);
     ob_start();
     include($view_template_file);
     return ob_get_clean();


### PR DESCRIPTION
Should also protect from inadvertent superglobals overrides.